### PR TITLE
Add model button to pull new ollama models

### DIFF
--- a/ClippyAI/ViewModels/MainViewModel.cs
+++ b/ClippyAI/ViewModels/MainViewModel.cs
@@ -243,4 +243,56 @@ public partial class MainViewModel : ViewModelBase
             IsBusy = false;
         }
     }
+
+    [RelayCommand]
+    public async Task AddModel()
+    {
+        try
+        {
+            var models = await OllamaService.GetModelsAsync();
+            ModelItems.Clear();
+            foreach (var model in models)
+            {
+                ModelItems.Add(model);
+            }
+        }
+        catch (Exception e)
+        {
+            ErrorMessages?.Add(e.Message);
+            ShowErrorMessage(e.Message);
+        }
+    }
+
+    [RelayCommand]
+    public async Task AddModelCommand()
+    {
+        try
+        {
+            // call ShowNotification method from MainWindow
+            if (Application.Current!.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                var mainWindow = (MainWindow)desktop.MainWindow!;
+                mainWindow.ShowNotification("ClippyAI", Resources.Resources.PleaseWait, true, false);
+            }
+
+            var models = await OllamaService.PullModelAsync();
+            ModelItems.Clear();
+            foreach (var model in models)
+            {
+                ModelItems.Add(model);
+            }
+
+            // call HideLastNotification method from MainWindow
+            if (Application.Current!.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                var mainWindow = (MainWindow)desktop.MainWindow!;
+                mainWindow.HideLastNotification();
+            }
+        }
+        catch (Exception e)
+        {
+            ErrorMessages?.Add(e.Message);
+            ShowErrorMessage(e.Message);
+        }
+    }
 }

--- a/ClippyAI/Views/MainView.axaml
+++ b/ClippyAI/Views/MainView.axaml
@@ -28,8 +28,11 @@
 
             <Label Content="{x:Static resources:Resources.Model}" HorizontalAlignment="Left" VerticalAlignment="Center" 
                   FontSize="14" Grid.Row="2" Grid.Column="0" Grid.RowSpan="1" />
-            <ComboBox x:Name="cboOllamaModel" SelectedItem="{Binding Model}" ItemsSource="{Binding ModelItems}"
-                  Grid.Row="2" Grid.Column="1" Width="180" />
+            <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.Column="1">
+                <ComboBox x:Name="cboOllamaModel" SelectedItem="{Binding Model}" ItemsSource="{Binding ModelItems}"
+                      Width="180" />
+                <Button Content="Add Model" Command="{Binding AddModelCommand}" Margin="10,0,0,0" />
+            </StackPanel>
             
             <Label Content="{x:Static resources:Resources.Language}" HorizontalAlignment="Left" VerticalAlignment="Center" 
                   FontSize="14" Grid.Row="4" Grid.Column="0" />

--- a/ClippyAI/Views/MainView.axaml.cs
+++ b/ClippyAI/Views/MainView.axaml.cs
@@ -44,6 +44,11 @@ public partial class MainView : UserControl
         var rbAuto = this.FindControl<RadioButton>("rbAuto");
         if (rbAuto != null)
             rbAuto.IsCheckedChanged += OnRbAutoChecked;
+
+        // add event handler for Add Model button click
+        var btnAddModel = this.FindControl<Button>("btnAddModel");
+        if (btnAddModel != null)
+            btnAddModel.Click += OnBtnAddModelClick;
     }
 
     private void MainView_Loaded(object? sender, RoutedEventArgs e)
@@ -202,5 +207,10 @@ public partial class MainView : UserControl
         config.AppSettings.Settings.Add("AutoMode", isChecked.ToString());
         config.Save(ConfigurationSaveMode.Modified);
         ConfigurationManager.RefreshSection("appSettings");
+    }
+
+    private void OnBtnAddModelClick(object? sender, RoutedEventArgs e)
+    {
+        ((MainViewModel)DataContext!).AddModelCommand.Execute(null);
     }
 }


### PR DESCRIPTION
Related to #7

Add functionality to pull new ollama models by adding an "Add Model" button next to the model textbox.

* Modify `ClippyAI/Views/MainView.axaml` to include a button labeled 'Add Model' next to the model textbox and bind its `Command` property to a new command in the `MainViewModel`.
* Add an event handler for the 'Add Model' button click event in `ClippyAI/Views/MainView.axaml.cs` and call the `AddModelCommand` from the `MainViewModel` in the event handler.
* Add a new `RelayCommand` named `AddModelCommand` in `ClippyAI/ViewModels/MainViewModel.cs` and implement it to call the `OllamaService.PullModelAsync` method and update the `ModelItems` collection.
* Add a notification while pulling the new ollama model in `ClippyAI/ViewModels/MainViewModel.cs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MrDoe/ClippyAI/issues/7?shareId=9802177d-0e7f-4726-840b-82823a77eb5c).